### PR TITLE
[#8] Redirect to `/dashboard` on file upload

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
   const { validFileAvailable } = useRunTrackingStore((state) => state);
 
   React.useEffect(() => {
-    if (validFileAvailable) {
+    if (!validFileAvailable) {
       router.push("/");
     }
   }, [router, validFileAvailable]);

--- a/src/app/generate-file/DashboardLoading/DashboardLoading.tsx
+++ b/src/app/generate-file/DashboardLoading/DashboardLoading.tsx
@@ -3,6 +3,7 @@ import GradientProgress from "~/components/GradientProgress/GradientProgress";
 import { Fade, Stack } from "@mui/material";
 import { useRouter } from "next/navigation";
 import { useRunTrackingStore } from "~/providers/RunTrackingStoreProvider";
+import { AppRoute } from "~/types/AppRoute/AppRoute";
 
 export default function DashboardLoading() {
   const router = useRouter();
@@ -11,7 +12,7 @@ export default function DashboardLoading() {
   React.useEffect(() => {
     const timeoutId = setTimeout(() => {
       setValidFileAvailable(true);
-      router.push("/dashboard");
+      router.push(AppRoute.DASHBOARD);
     }, 3000);
 
     return () => {

--- a/src/components/FileDropZone/FileDropZone.tsx
+++ b/src/components/FileDropZone/FileDropZone.tsx
@@ -6,6 +6,8 @@ import { validateUserFile } from "~/utils/validateUserFile";
 import { useRunTrackingStore } from "~/providers/RunTrackingStoreProvider";
 import * as stylex from "@stylexjs/stylex";
 import { useNotification } from "~/providers/NotificationProvider";
+import { useRouter } from "next/navigation";
+import { AppRoute } from "~/types/AppRoute/AppRoute";
 
 const pulse = stylex.keyframes({
   "0%": { borderColor: "#fef08a", color: "#fef08a" },
@@ -35,6 +37,7 @@ const styles = stylex.create({
 });
 
 export default function FileDropZone() {
+  const router = useRouter();
   const { notifySuccess, notifyFailure } = useNotification();
   const { setValidFileAvailable, setName, setMetricType } = useRunTrackingStore(
     (state) => state
@@ -51,6 +54,7 @@ export default function FileDropZone() {
             setName(data.userFile.name);
             setMetricType(data.userFile.metricType);
             notifySuccess("File successfully validated");
+            router.push(AppRoute.DASHBOARD);
             // TODO: When Shoe and Run data is available, set in memory state
           }
         })

--- a/src/types/AppRoute/AppRoute.ts
+++ b/src/types/AppRoute/AppRoute.ts
@@ -1,0 +1,3 @@
+export enum AppRoute {
+  DASHBOARD = "/dashboard",
+}


### PR DESCRIPTION
#8 
- Redirects user to `/dashboard` on successful file upload
- Adds `AppRoute` enum to store app routes
- Update condition for `/dashboard` page to redirect home (unavailable valid file)